### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/com/intervigil/micdroid/Constants.java
+++ b/app/src/main/java/com/intervigil/micdroid/Constants.java
@@ -48,4 +48,6 @@ public class Constants {
 
     // mime type
     public static final String MIME_AUDIO_WAV = "audio/x-wav";
+
+    private Constants() {}
 }

--- a/app/src/main/java/com/intervigil/micdroid/helper/AdHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/AdHelper.java
@@ -24,6 +24,8 @@ import com.google.android.gms.ads.AdView;
 
 public class AdHelper {
 
+    private AdHelper() {}
+
     public static void updateAdView(AdView ad, boolean enabled) {
         if (enabled) {
             ad.setEnabled(true);

--- a/app/src/main/java/com/intervigil/micdroid/helper/ApplicationHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/ApplicationHelper.java
@@ -24,6 +24,8 @@ import android.content.pm.PackageManager.NameNotFoundException;
 
 public class ApplicationHelper {
 
+    private ApplicationHelper() {}
+
     public static int getPackageVersion(Context context) {
         int versionCode = -1;
         try {

--- a/app/src/main/java/com/intervigil/micdroid/helper/AudioHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/AudioHelper.java
@@ -24,6 +24,8 @@ import android.media.AudioFormat;
 public class AudioHelper {
     private static final String TAG = "AudioHelper";
 
+    private AudioHelper() {}
+
     /**
      * Convert Android AudioFormat.CHANNEL_CONFIGURATION constants to integers
      *

--- a/app/src/main/java/com/intervigil/micdroid/helper/DialogHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/DialogHelper.java
@@ -29,6 +29,8 @@ import com.intervigil.micdroid.R;
 
 public class DialogHelper {
 
+    private DialogHelper() {}
+
     public static void showWarning(Context context, int titleId, int warningId) {
         Builder warningBuilder = new AlertDialog.Builder(context);
         warningBuilder.setMessage(context.getString(warningId)).setTitle(

--- a/app/src/main/java/com/intervigil/micdroid/helper/HeadsetHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/HeadsetHelper.java
@@ -28,6 +28,8 @@ public class HeadsetHelper {
 
     private static final String EXTRA_HEADSET_STATE_KEY = "state";
 
+    private HeadsetHelper() {}
+
     public static boolean isHeadsetPluggedIn(Context context) {
         Intent headsetIntent = context.registerReceiver(null, new IntentFilter(
                 Intent.ACTION_HEADSET_PLUG));

--- a/app/src/main/java/com/intervigil/micdroid/helper/MediaStoreHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/MediaStoreHelper.java
@@ -34,6 +34,8 @@ import java.io.File;
 
 public class MediaStoreHelper {
 
+    private MediaStoreHelper() {}
+
     public static Uri getRecordingUri(Context context, Recording recording) {
         ContentResolver resolver = context.getContentResolver();
         if (resolver != null) {

--- a/app/src/main/java/com/intervigil/micdroid/helper/PreferenceHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/PreferenceHelper.java
@@ -27,6 +27,9 @@ import com.intervigil.micdroid.Constants;
 import com.intervigil.micdroid.R;
 
 public class PreferenceHelper {
+
+    private PreferenceHelper() {}
+
     public static int getLastVersionCode(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getInt(
                 Constants.KEY_LAST_VERSION_CODE, -1);

--- a/app/src/main/java/com/intervigil/micdroid/helper/RecordingOptionsHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/RecordingOptionsHelper.java
@@ -31,6 +31,8 @@ import java.io.File;
 
 public class RecordingOptionsHelper {
 
+    private RecordingOptionsHelper() {}
+
     public static boolean setRingTone(Context context, Recording recording) {
         Uri recordingUri = MediaStoreHelper.getRecordingUri(context, recording);
         if (recordingUri != null) {

--- a/app/src/main/java/com/intervigil/micdroid/helper/UpdateHelper.java
+++ b/app/src/main/java/com/intervigil/micdroid/helper/UpdateHelper.java
@@ -22,6 +22,9 @@ package com.intervigil.micdroid.helper;
 import android.content.Context;
 
 public class UpdateHelper {
+
+    private UpdateHelper() {}
+
     /*
      * One time updates when app has been updated goes here Currently we always
      * show startup dialog, and reset default recording settings


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed