### PR TITLE
General code quality fix-1

### DIFF
--- a/app/src/main/java/com/intervigil/micdroid/AudioController.java
+++ b/app/src/main/java/com/intervigil/micdroid/AudioController.java
@@ -77,13 +77,13 @@ public class AudioController {
     }
 
     public void configureRecorder() {
-        int sampleRates[] = {
+        int[] sampleRates = {
                 Constants.SAMPLE_RATE_44KHZ,
                 Constants.SAMPLE_RATE_22KHZ,
                 Constants.SAMPLE_RATE_11KHZ,
                 Constants.SAMPLE_RATE_8KHZ,
         };
-        double multipliers[] = {
+        double[] multipliers = {
                 1.0, 0.5, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0
         };
 

--- a/app/src/main/java/com/intervigil/micdroid/MicFragment.java
+++ b/app/src/main/java/com/intervigil/micdroid/MicFragment.java
@@ -47,7 +47,7 @@ public class MicFragment extends Fragment {
     public void onActivityCreated(Bundle icicle) {
         super.onActivityCreated(icicle);
 
-        ToggleButton mRecordButton = ((ToggleButton) getView().findViewById(R.id.recording_button));
+        ToggleButton mRecordButton = (ToggleButton) getView().findViewById(R.id.recording_button);
         mRecordButton.setChecked(false);
         mRecordButton.setOnCheckedChangeListener(recordBtnListener);
 

--- a/app/src/main/java/com/intervigil/micdroid/SipdroidRecorder.java
+++ b/app/src/main/java/com/intervigil/micdroid/SipdroidRecorder.java
@@ -103,9 +103,9 @@ public class SipdroidRecorder {
     }
 
     public boolean isRunning() {
-        return (mWriterThread != null
+        return mWriterThread != null
                 && mWriterThread.getState() != Thread.State.NEW && mWriterThread
-                .getState() != Thread.State.TERMINATED);
+                .getState() != Thread.State.TERMINATED;
     }
 
     private Handler recorderHandler = new Handler() {

--- a/app/src/main/java/com/intervigil/wave/WaveReader.java
+++ b/app/src/main/java/com/intervigil/wave/WaveReader.java
@@ -59,7 +59,7 @@ public class WaveReader {
     public void openWave() throws IOException {
         int headerId = readUnsignedInt(mInputStream);  // should be "RIFF"
         if (headerId != WAV_HEADER_CHUNK_ID) {
-            throw new InvalidWaveException(("Invalid WAVE header chunk ID: " + headerId));
+            throw new InvalidWaveException("Invalid WAVE header chunk ID: " + headerId);
         }
         mFileSize = readUnsignedIntLE(mInputStream);  // length of header
         int format = readUnsignedInt(mInputStream);  // should be "WAVE"
@@ -219,10 +219,10 @@ public class WaveReader {
         if (ret == -1) {
             return -1;
         } else {
-            return (((buf[0] & 0xFF) << 24)
+            return ((buf[0] & 0xFF) << 24)
                     | ((buf[1] & 0xFF) << 16)
                     | ((buf[2] & 0xFF) << 8)
-                    | (buf[3] & 0xFF));
+                    | (buf[3] & 0xFF);
         }
     }
 
@@ -233,10 +233,10 @@ public class WaveReader {
         if (ret == -1) {
             return -1;
         } else {
-            return (buf[0] & 0xFF
+            return buf[0] & 0xFF
                     | ((buf[1] & 0xFF) << 8)
                     | ((buf[2] & 0xFF) << 16)
-                    | ((buf[3] & 0xFF) << 24));
+                    | ((buf[3] & 0xFF) << 24);
         }
     }
 

--- a/app/src/main/java/com/intervigil/wave/WaveWriter.java
+++ b/app/src/main/java/com/intervigil/wave/WaveWriter.java
@@ -74,7 +74,7 @@ public class WaveWriter {
         }
         if (offset > length) {
             throw new IndexOutOfBoundsException(
-                    ("offset " + offset + " is greater than length " + length));
+                    "offset " + offset + " is greater than length " + length);
         }
         for (int i = offset; i < length; i++) {
             writeUnsignedShortLE(mOutputStream, src[i]);
@@ -98,7 +98,7 @@ public class WaveWriter {
         }
         if (offset > length) {
             throw new IndexOutOfBoundsException(
-                    ("offset " + offset + " is greater than length " + length));
+                    "offset " + offset + " is greater than length " + length);
         }
         for (int i = offset; i < length; i++) {
             writeUnsignedShortLE(mOutputStream, left[i]);
@@ -146,7 +146,7 @@ public class WaveWriter {
 
     private static void writeUnsignedIntLE(OutputStream stream, int sample)
             throws IOException {
-        stream.write((sample & 0x000000ff));
+        stream.write(sample & 0x000000ff);
         stream.write((sample & 0x0000ff00) >> 8);
         stream.write((sample & 0x00ff0000) >> 16);
         stream.write((sample & 0xff000000) >> 24);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed
